### PR TITLE
Update Dockerfile: PHP 7.4 brings typecasting the class properties and does not bring any breaking changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli
+FROM php:7.4-cli
 
 RUN apt-get update && apt-get -y install zip unzip
 


### PR DESCRIPTION
A Separate branch can be created for PHP 7.4 support if required